### PR TITLE
Add support for new pull_request_target event

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -127,7 +127,7 @@ export async function run(): Promise<void> {
 
     // Render template
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const assignees = (context.payload as any).issue.assignees;
+    const assignees = (context.payload as any)?.issue?.assignees ?? [];
     if (core.isDebug()) {
       console.log(assignees);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -106,7 +106,7 @@ export async function run(): Promise<void> {
         core.info(`[INFO] no configuration labels.${labelName}.${labelEvent}.${eventType}`);
         return;
       }
-    } else if (eventName === 'pull_request') {
+    } else if (eventName === 'pull_request' || eventName === 'pull_request_target') {
       eventType = 'pr';
       if (config.labels[labelIndex][`${labelEvent}`].pr === void 0) {
         core.info(`[INFO] no configuration labels.${labelName}.${labelEvent}.${eventType}`);


### PR DESCRIPTION
The new event is similar to `pull_request`
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

The payload may be different so assignees was throwing an error.