### PR TITLE
ci: Install actionlint

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,25 @@
+name: Lint Workflows
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/*'
+  pull_request:
+    paths:
+      - '.github/workflows/*'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-20.04
+    timeout-minutes: 1
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash


### PR DESCRIPTION
[rhysd/actionlint: Static checker for GitHub Actions workflow files](https://github.com/rhysd/actionlint#ci-services)

Blocked by https://github.com/rhysd/actionlint/pull/8