### PR TITLE
docs: add note about changed action triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Scenario:
 > [Authenticating with the GITHUB_TOKEN - GitHub Docs](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#using-the-github_token-in-a-workflow)
 >
 > When you use the repository's `GITHUB_TOKEN` to perform tasks on behalf of the GitHub Actions app, events triggered by the `GITHUB_TOKEN` will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
+> 
+> An exception are the `workflow_dispatch` and `repository_dispatch` events which can be triggered by another GitHub Action.
 
 You need to provide a personal access token (with [`public_repo`] for a public repository, [`repo`] for a private repository) to an auto label GitHub Actions or GitHub Bot like [actions/labeler](https://github.com/actions/labeler).
 

--- a/README.md
+++ b/README.md
@@ -282,9 +282,7 @@ Scenario:
 
 > [Authenticating with the GITHUB_TOKEN - GitHub Docs](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#using-the-github_token-in-a-workflow)
 >
-> When you use the repository's `GITHUB_TOKEN` to perform tasks on behalf of the GitHub Actions app, events triggered by the `GITHUB_TOKEN` will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when push events occur.
-> 
-> An exception are the `workflow_dispatch` and `repository_dispatch` events which can be triggered by another GitHub Action.
+> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN`, with the exception of `workflow_dispatch` and `repository_dispatch`, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. For example, if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run even when the repository contains a workflow configured to run when `push` events occur.
 
 You need to provide a personal access token (with [`public_repo`] for a public repository, [`repo`] for a private repository) to an auto label GitHub Actions or GitHub Bot like [actions/labeler](https://github.com/actions/labeler).
 


### PR DESCRIPTION
GitHub recently changed how Actions get triggered.

A GitHub Action workflow using `workflow_dispatch` and/or `repository_dispatch` as their trigger can now be activated using another GitHub Action.
This PR adds these two events as exceptions to the "Actions can't trigger other actions" note.

Relevant Blog Post: https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/